### PR TITLE
bluetooth: Our kernel is missing CLOCK_BOOTTIME_ALARM (alarmtimer)

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -19,4 +19,7 @@
 
 #define BTA_HOST_INTERLEAVE_SEARCH  TRUE
 
+/* Defined if the kernel does not have support for CLOCK_BOOTTIME_ALARM */
+#define KERNEL_MISSING_CLOCK_BOOTTIME_ALARM TRUE
+
 #endif


### PR DESCRIPTION
Kernel is still using drivers/rtc/alarm.c, instead of the newer kernel/time/alarmtimer.c