### PR TITLE
init: qcamerasvr: Remove cpuset setting

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -324,7 +324,6 @@ service qcamerasvr /system/vendor/bin/mm-qcamera-daemon
     class late_start
     user camera
     group camera system inet input graphics
-    writepid /dev/cpuset/camera-daemon/tasks
 
 # QCOM sensors
 service sensors /system/vendor/bin/sensors.qcom


### PR DESCRIPTION
init: couldn't write 316 to /dev/cpuset/camera-daemon/tasks: No such file or directory

We could create it, but I don't know what would the optimal values be, so let's remove it.