### PR TITLE
platform.mk: Use legacy camera HIDL fork

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -238,8 +238,8 @@ PRODUCT_PACKAGES += \
 
 # Camera HIDL interfaces
 PRODUCT_PACKAGES += \
-    android.hardware.camera.provider@2.4-impl \
-    camera.device@1.0-impl
+    android.hardware.camera.provider@2.4-impl.legacy \
+    camera.device@1.0-impl.legacy
 
 # Snap
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Instead of NON_TREBLE_CAMERA flag
https://review.lineageos.org/#/c/190822/